### PR TITLE
Display archive header

### DIFF
--- a/app/models/post-model.js
+++ b/app/models/post-model.js
@@ -58,7 +58,7 @@ define([
     getTerm: function (taxonomy, term) {
       var terms = this.get('terms')[taxonomy],
           index = _.findIndex(terms, function (elem) {
-            return term.indexOf(elem.slug) > -1;
+            return elem.slug === term || term.endsWith('/' + elem.slug);
           });
 
       return index > -1 ? new Term(terms[index]) : new Term();


### PR DESCRIPTION
Closes #36 

Think this solves the issue. The problem was that the sub-category has this format "category/sub-category", while the term only has "sub-category". We only needed to make sure that the received sub-category partially matches the term.
